### PR TITLE
Add slow fade-in animation to hero badge text

### DIFF
--- a/src/components/HeroTopBadge.tsx
+++ b/src/components/HeroTopBadge.tsx
@@ -7,9 +7,9 @@ export default function HeroTopBadge() {
     <div className="pointer-events-none absolute top-20 md:top-22 left-1/2 -translate-x-1/2 z-40 text-center">
       {/* 슬로건 */}
       <motion.div
-        initial={{ opacity: 0, y: -8 }}
-        animate={{ opacity: 1, y: 0 }}
-        transition={{ duration: 1, ease: "easeOut" }}
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        transition={{ duration: 1.8, ease: "easeOut", delay: 0.2 }}
         className="text-xl text-2xl text-black drop-shadow-[0_1px_2px_rgba(0,0,0,0.6)]"
       >
         “쉽게 길들여지지 않는 고양이들처럼”
@@ -17,9 +17,9 @@ export default function HeroTopBadge() {
 
       {/* 로고 이미지 (public/logo.png) */}
       <motion.div
-        initial={{ opacity: 0, y: 0 }}
-        animate={{ opacity: 1, y: 0 }}
-        transition={{ duration: 1, ease: "easeOut" }}
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        transition={{ duration: 1.8, ease: "easeOut", delay: 0.6 }}
         className="mt-0 inline-flex items-center justify-center px-5 md:px-6 py-2 md:py-2.5 pointer-events-auto"
       >
         <Image
@@ -32,18 +32,18 @@ export default function HeroTopBadge() {
         />
       </motion.div>
       <motion.div
-        initial={{ opacity: 0, y: 0 }}
-        animate={{ opacity: 1, y: 0 }}
-        transition={{ duration: 1, ease: "easeOut" }}
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        transition={{ duration: 1.8, ease: "easeOut", delay: 1 }}
         className="text-xl text-2xl text-black drop-shadow-[0_1px_2px_rgba(0,0,0,0.6)]"
       >
         since 1989
       </motion.div>
 
       <motion.div
-        initial={{ opacity: 0, y: 0 }}
-        animate={{ opacity: 1, y: 0 }}
-        transition={{ duration: 1, ease: "easeOut" }}
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        transition={{ duration: 1.8, ease: "easeOut", delay: 1.4 }}
         className="text-xl text-2xl text-black drop-shadow-[0_1px_2px_rgba(0,0,0,0.6)]"
       >
         홍대 앞 본원


### PR DESCRIPTION
## Summary
- update HeroTopBadge animations so slogan, logo, and info text fade in place with gentle delays

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e60b8fef788325b582178ae15139e7